### PR TITLE
feat: Add Barometric Driver

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,5 +10,5 @@ rustflags = [
 [env]
 DEFMT_LOG="info"
 
-[build] 
+[build]
 target = "thumbv7em-none-eabihf"     # Cortex-M4F and Cortex-M7F (with FPU)

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,5 +10,5 @@ rustflags = [
 [env]
 DEFMT_LOG="info"
 
-[build]
+[build] 
 target = "thumbv7em-none-eabihf"     # Cortex-M4F and Cortex-M7F (with FPU)

--- a/crates/common-arm/src/drivers/MS5611DriverSpecs.md
+++ b/crates/common-arm/src/drivers/MS5611DriverSpecs.md
@@ -1,0 +1,219 @@
+# MS5611-01BA03 Driver Specifications
+
+This document outlines the necessary specifications extracted from the datasheet for developing a software driver for the MS5611-01BA03 barometric pressure sensor.
+
+## 1. General Information
+
+*   **Device:** MS5611-01BA03 Barometric Pressure Sensor
+*   **Key Features:** High resolution (10 cm), I2C/SPI interface, integrated 24-bit ADC, internal oscillator, factory calibration.
+*   **Sensing:** Pressure and Temperature
+
+## 2. Electrical Characteristics (Relevant to Driver)
+
+*   **Supply Voltage (VDD):** 1.8 V to 3.6 V (Typical 3.0 V used for some specs)
+*   **Supply Current (IDD @ 3V, 1 sample/sec):**
+    *   Depends on Oversampling Ratio (OSR)
+    *   OSR 4096: 12.5 µA (typ)
+    *   OSR 2048: 6.3 µA (typ)
+    *   OSR 1024: 3.2 µA (typ)
+    *   OSR 512: 1.7 µA (typ)
+    *   OSR 256: 0.9 µA (typ)
+*   **Peak Supply Current:** 1.4 mA (during conversion)
+*   **Standby Current (@ 25°C):** 0.02 µA (typ), < 0.15 µA (max)
+*   **Internal Oscillator:** Yes, no external clock required for sensor operation.
+
+## 3. Communication Interfaces
+
+The sensor supports both SPI and I2C interfaces, selected by the `PS` pin.
+
+*   **Protocol Selection (Pin 2 - PS):**
+    *   `PS` High (VDD): I²C Mode
+    *   `PS` Low (GND): SPI Mode
+
+### 3.1. SPI Interface
+
+*   **Pins:**
+    *   `SCLK` (Pin 8): Serial Clock Input
+    *   `SDI` (Pin 7): Serial Data Input
+    *   `SDO` (Pin 6): Serial Data Output
+    *   `CSB` (Pin 4): Chip Select (Active Low)
+*   **Modes:** Supports SPI Mode 0 (CPOL=0, CPHA=0) and Mode 3 (CPOL=1, CPHA=1).
+*   **Max Clock Speed (SCLK):** 20 MHz
+*   **Data Transfer:** MSB first for both commands and data.
+*   **Chip Select (CSB):** Must be low to enable communication. Can be kept low during a command sequence or de-asserted (high) between commands or after conversion completion. For best noise performance, keep the SPI bus idle during ADC conversions.
+
+### 3.2. I²C Interface
+
+*   **Pins:**
+    *   `SCLK` (Pin 8): Serial Clock Input
+    *   `SDA` (Pin 7): Serial Data Input/Output (Bidirectional)
+    *   `CSB` (Pin 4): Determines LSB of I²C address. Must be connected to VDD or GND (cannot be left floating).
+*   **Max Clock Speed (SCLK):** Standard I2C speeds likely supported (datasheet mentions up to 20 MHz interface, but typically I2C is 100kHz, 400kHz, sometimes 1MHz). Test specific speed.
+*   **Device Address:** 7-bit address format: `111011C`
+    *   If `CSB` is Low (GND): Address = `1110110` (0x76)
+    *   If `CSB` is High (VDD): Address = `1110111` (0x77)
+    *   The R/W bit is appended for read (1) or write (0) operations.
+        *   CSB=0: Write Address = `0xEC`, Read Address = `0xED`
+        *   CSB=1: Write Address = `0xEE`, Read Address = `0xEF`
+*   **Data Transfer:** MSB first. Requires ACK from sensor after address/command bytes, and ACK from master after reading data bytes (except the last one, which requires NACK).
+
+## 4. Commands
+
+The sensor has 5 basic command types. Commands are 1 byte (8 bits).
+
+### 4.1. Command List (SPI & I2C)
+
+| Command Description        | OSR   | Hex Value | Notes                                      |
+| :------------------------- | :---- | :-------- | :----------------------------------------- |
+| Reset                      | N/A   | `0x1E`    | Reloads PROM calibration data.             |
+| Convert D1 (Pressure)      | 256   | `0x40`    | Starts pressure conversion.                |
+| Convert D1 (Pressure)      | 512   | `0x42`    | Starts pressure conversion.                |
+| Convert D1 (Pressure)      | 1024  | `0x44`    | Starts pressure conversion.                |
+| Convert D1 (Pressure)      | 2048  | `0x46`    | Starts pressure conversion.                |
+| Convert D1 (Pressure)      | 4096  | `0x48`    | Starts pressure conversion.                |
+| Convert D2 (Temperature)   | 256   | `0x50`    | Starts temperature conversion.             |
+| Convert D2 (Temperature)   | 512   | `0x52`    | Starts temperature conversion.             |
+| Convert D2 (Temperature)   | 1024  | `0x54`    | Starts temperature conversion.             |
+| Convert D2 (Temperature)   | 2048  | `0x56`    | Starts temperature conversion.             |
+| Convert D2 (Temperature)   | 4096  | `0x58`    | Starts temperature conversion.             |
+| ADC Read                   | N/A   | `0x00`    | Reads the 24-bit result of last conversion. |
+| PROM Read (Address 0)      | N/A   | `0xA0`    | Reads 16-bit PROM Word 0 (Reserved).       |
+| PROM Read (Address 1 / C1) | N/A   | `0xA2`    | Reads 16-bit PROM Word 1 (SENST1).         |
+| PROM Read (Address 2 / C2) | N/A   | `0xA4`    | Reads 16-bit PROM Word 2 (OFFT1).          |
+| PROM Read (Address 3 / C3) | N/A   | `0xA6`    | Reads 16-bit PROM Word 3 (TCS).            |
+| PROM Read (Address 4 / C4) | N/A   | `0xA8`    | Reads 16-bit PROM Word 4 (TCO).            |
+| PROM Read (Address 5 / C5) | N/A   | `0xAA`    | Reads 16-bit PROM Word 5 (TREF).           |
+| PROM Read (Address 6 / C6) | N/A   | `0xAC`    | Reads 16-bit PROM Word 6 (TEMPSENS).       |
+| PROM Read (Address 7 / CRC)| N/A   | `0xAE`    | Reads 16-bit PROM Word 7 (Serial/CRC).     |
+
+### 4.2. Command Execution Notes
+
+*   **Reset:** Send `0x1E`. Wait required time (see Timing section) for PROM reload. Must be done once after power-on.
+*   **Conversion:** Send a `Convert D1` or `Convert D2` command. The sensor becomes busy. Wait for the conversion time (see Timing section).
+*   **ADC Read:** After conversion time, send `0x00`. Read the 24-bit result (MSB first). If read before conversion is complete, or read twice, result will be `0`. Sending a new conversion command during an ongoing conversion yields incorrect results.
+*   **PROM Read:** Send the appropriate `0xA*` command. Read the 16-bit result (MSB first). PROM should be read after Reset to get calibration coefficients.
+
+## 5. Data Acquisition and Processing
+
+### 5.1. Typical Sequence
+
+1.  Power on the sensor.
+2.  Send `Reset` command (`0x1E`).
+3.  Wait for reset completion (2.8 ms).
+4.  Read all 8 PROM words (`0xA0` to `0xAE`) to get calibration coefficients (C1-C6) and CRC. Store these coefficients.
+5.  *Optional:* Validate CRC (see Section 6).
+6.  Send `Convert D2` command (e.g., `0x58` for OSR=4096).
+7.  Wait for temperature conversion time (e.g., 8.22 ms typ for OSR=4096).
+8.  Send `ADC Read` command (`0x00`).
+9.  Read 24-bit raw temperature value (D2).
+10. Send `Convert D1` command (e.g., `0x48` for OSR=4096).
+11. Wait for pressure conversion time (e.g., 8.22 ms typ for OSR=4096).
+12. Send `ADC Read` command (`0x00`).
+13. Read 24-bit raw pressure value (D1).
+14. Calculate temperature and compensated pressure using D1, D2, and C1-C6 (see Section 5.2).
+15. Repeat steps 6-14 for continuous measurements.
+
+### 5.2. Pressure and Temperature Calculation
+
+**(Based on Figure 2 and Figure 3, requires 64-bit integer support for intermediate values)**
+
+**Variables:**
+*   `C1` to `C6`: 16-bit unsigned integers from PROM.
+*   `D1`: 24-bit unsigned raw pressure from ADC.
+*   `D2`: 24-bit unsigned raw temperature from ADC.
+
+**First Order Calculation:**
+1.  `dT = D2 - C5 * 2^8` (Result is signed 32-bit)
+2.  `TEMP = 2000 + dT * C6 / 2^23` (Result is signed 32-bit, represents temp in 0.01 °C, e.g., 2007 = 20.07°C)
+3.  `OFF = C2 * 2^16 + (C4 * dT) / 2^7` (Intermediate result needs signed 64-bit)
+4.  `SENS = C1 * 2^15 + (C3 * dT) / 2^8` (Intermediate result needs signed 64-bit)
+5.  `P = (D1 * SENS / 2^21 - OFF) / 2^15` (Result is signed 32-bit, represents pressure in 0.01 mbar, e.g., 100009 = 1000.09 mbar)
+
+**Second Order Temperature Compensation (Recommended for better accuracy):**
+Apply *after* calculating `TEMP`, `OFF`, `SENS` from the first order steps.
+1.  Initialize `T2 = 0`, `OFF2 = 0`, `SENS2 = 0`.
+2.  **If `TEMP < 2000`:**
+    *   `T2 = (dT * dT) / 2^31` (Use 64-bit intermediate for `dT*dT`)
+    *   `OFF2 = 5 * (TEMP - 2000)^2 / 2^1` (Use 64-bit intermediate)
+    *   `SENS2 = 5 * (TEMP - 2000)^2 / 2^2` (Use 64-bit intermediate)
+    *   **If `TEMP < -1500`:**
+        *   `OFF2 = OFF2 + 7 * (TEMP + 1500)^2` (Use 64-bit intermediate)
+        *   `SENS2 = SENS2 + 11 * (TEMP + 1500)^2 / 2^1` (Use 64-bit intermediate)
+3.  **Apply Corrections:**
+    *   `TEMP = TEMP - T2`
+    *   `OFF = OFF - OFF2`
+    *   `SENS = SENS - SENS2`
+4.  **Recalculate Final Pressure:**
+    *   `P = (D1 * SENS / 2^21 - OFF) / 2^15` (Result is signed 32-bit, pressure in 0.01 mbar)
+
+**Final Output:**
+*   Temperature = `TEMP / 100.0` (°C)
+*   Pressure = `P / 100.0` (mbar)
+
+## 6. PROM and Calibration Data
+
+*   **Structure:** 128 bits (8 words of 16 bits).
+    *   Word 0: Reserved / Factory Data
+    *   Word 1-6: Calibration Coefficients C1-C6 (16-bit unsigned)
+    *   Word 7: Upper bits Serial Code, Lower 4 bits CRC.
+*   **Coefficients:**
+    *   C1: Pressure sensitivity (SENST1)
+    *   C2: Pressure offset (OFFT1)
+    *   C3: Temperature coefficient of pressure sensitivity (TCS)
+    *   C4: Temperature coefficient of pressure offset (TCO)
+    *   C5: Reference temperature (TREF)
+    *   C6: Temperature coefficient of the temperature (TEMPSENS)
+*   **CRC:** 4-bit CRC calculated over PROM words 0-7 (excluding the CRC bits themselves). Checksum algorithm details are in Application Note AN520. Can be used to verify PROM data integrity after reading.
+
+## 7. Timing Specifications
+
+*   **Reset Command (`0x1E`) Reload Time:** 2.8 ms (max) - must wait this long after sending reset before next command.
+*   **Conversion Time (tc):** Depends on OSR. Time between sending `Convert` command and data being ready for `ADC Read`.
+
+| OSR   | Min (ms) | Typ (ms) | Max (ms) |
+| :---- | :------- | :------- | :------- |
+| 4096  | 7.40     | 8.22     | 9.04     |
+| 2048  | 3.72     | 4.13     | 4.54     |
+| 1024  | 1.88     | 2.08     | 2.28     |
+| 512   | 0.95     | 1.06     | 1.17     |
+| 256   | 0.48     | 0.54     | 0.60     |
+
+*   **ADC Read:** Data (24 bits for ADC, 16 bits for PROM) is clocked out synchronously with SCLK after the `ADC Read` or `PROM Read` command is sent.
+
+## 8. Resolution
+
+*   **Pressure ADC:** 24 bits
+*   **Temperature ADC:** 24 bits
+*   **Pressure Resolution (RMS @ 3V, 25°C):** Depends on OSR.
+    *   OSR 4096: 0.012 mbar
+    *   OSR 2048: 0.018 mbar
+    *   OSR 1024: 0.027 mbar
+    *   OSR 512: 0.042 mbar
+    *   OSR 256: 0.065 mbar
+*   **Temperature Resolution (RMS @ 3V, 25°C):** Depends on OSR.
+    *   OSR 4096: 0.002 °C
+    *   OSR 2048: 0.003 °C
+    *   OSR 1024: 0.005 °C
+    *   OSR 512: 0.008 °C
+    *   OSR 256: 0.012 °C
+*   **Altitude Resolution:** High resolution mode (OSR 4096) typically provides ~10 cm resolution.
+
+## 9. Pin Configuration Summary
+
+| Pin | Name    | Type   | Function (SPI Mode)              | Function (I2C Mode)             |
+| :-- | :------ | :----- | :------------------------------- | :------------------------------ |
+| 1   | VDD     | P      | Positive Supply Voltage          | Positive Supply Voltage         |
+| 2   | PS      | I      | Protocol Select (Tie Low)        | Protocol Select (Tie High)      |
+| 3   | GND     | G      | Ground                           | Ground                          |
+| 4   | CSB     | I      | Chip Select (Active Low)         | Address Select LSB (Tie High/Low)|
+| 5   | NC      | -      | No Connect (Internal Connection) | No Connect (Internal Connection)|
+| 6   | SDO     | O      | Serial Data Output               | No Connect (NC)                 |
+| 7   | SDI/SDA | I/O    | Serial Data Input                | Serial Data I/O                 |
+| 8   | SCLK    | I      | Serial Clock                     | Serial Clock                    |
+
+## 10. Important Hardware Notes
+
+*   **Decoupling Capacitor:** A 100 nF ceramic capacitor must be placed close to the VDD pin (Pin 1) and connected to GND (Pin 3) to stabilize the power supply during conversions and ensure accuracy.
+*   **I2C Pull-up Resistors:** Required on SDA and SCLK lines (typical values 4.7kΩ - 10kΩ).
+*   **PS Pin:** Must be tied high or low to select the interface; do not leave floating.
+*   **CSB Pin (I2C Mode):** Must be tied high or low to set the address; do not leave floating.

--- a/crates/common-arm/src/drivers/mod.rs
+++ b/crates/common-arm/src/drivers/mod.rs
@@ -1,0 +1,2 @@
+#[doc = include_str!("./MS5611DriverSpecs.md")]
+pub mod ms5611;

--- a/crates/common-arm/src/drivers/ms5611.rs
+++ b/crates/common-arm/src/drivers/ms5611.rs
@@ -1,0 +1,347 @@
+//! Driver for the MS5611 Barometric Pressure Sensor
+use embedded_hal::{
+    blocking::{
+        delay::DelayUs,
+        spi::{Transfer, Write},
+    },
+    digital::v2::OutputPin,
+};
+
+// According to datasheet section 4.1
+mod command {
+    pub const RESET: u8 = 0x1E;
+    pub const ADC_READ: u8 = 0x00;
+    // Convert D1 (Pressure)
+    pub const CONVERT_D1_OSR_256: u8 = 0x40;
+    pub const CONVERT_D1_OSR_512: u8 = 0x42;
+    pub const CONVERT_D1_OSR_1024: u8 = 0x44;
+    pub const CONVERT_D1_OSR_2048: u8 = 0x46;
+    pub const CONVERT_D1_OSR_4096: u8 = 0x48;
+    // Convert D2 (Temperature)
+    pub const CONVERT_D2_OSR_256: u8 = 0x50;
+    pub const CONVERT_D2_OSR_512: u8 = 0x52;
+    pub const CONVERT_D2_OSR_1024: u8 = 0x54;
+    pub const CONVERT_D2_OSR_2048: u8 = 0x56;
+    pub const CONVERT_D2_OSR_4096: u8 = 0x58;
+    // PROM Read
+    // pub const PROM_READ_ADDR_0: u8 = 0xA0; // Reserved
+    pub const PROM_READ_ADDR_1: u8 = 0xA2; // C1 Pressure sensitivity (SENST1)
+    pub const PROM_READ_ADDR_2: u8 = 0xA4; // C2 Pressure offset (OFFT1)
+    pub const PROM_READ_ADDR_3: u8 = 0xA6; // C3 Temperature coefficient of pressure sensitivity (TCS)
+    pub const PROM_READ_ADDR_4: u8 = 0xA8; // C4 Temperature coefficient of pressure offset (TCO)
+    pub const PROM_READ_ADDR_5: u8 = 0xAA; // C5 Reference temperature (TREF)
+    pub const PROM_READ_ADDR_6: u8 = 0xAC; // C6 Temperature coefficient of the temperature (TEMPSENS)
+                                           // pub const PROM_READ_ADDR_7: u8 = 0xAE; // C7 Serial Code & CRC
+}
+
+/// Oversampling Ratio (OSR) options
+/// Higher OSR means higher precision but longer conversion times and higher power consumption.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum OversamplingRatio {
+    /// 256 samples, ~0.60 ms conversion time
+    Osr256,
+    /// 512 samples, ~1.17 ms conversion time
+    Osr512,
+    /// 1024 samples, ~2.28 ms conversion time
+    Osr1024,
+    /// 2048 samples, ~4.54 ms conversion time
+    Osr2048,
+    /// 4096 samples, ~9.04 ms conversion time
+    Osr4096,
+}
+
+impl OversamplingRatio {
+    /// Get the command byte for starting a pressure (D1) conversion
+    fn pressure_command(self) -> u8 {
+        match self {
+            OversamplingRatio::Osr256 => command::CONVERT_D1_OSR_256,
+            OversamplingRatio::Osr512 => command::CONVERT_D1_OSR_512,
+            OversamplingRatio::Osr1024 => command::CONVERT_D1_OSR_1024,
+            OversamplingRatio::Osr2048 => command::CONVERT_D1_OSR_2048,
+            OversamplingRatio::Osr4096 => command::CONVERT_D1_OSR_4096,
+        }
+    }
+
+    /// Get the command byte for starting a temperature (D2) conversion
+    fn temperature_command(self) -> u8 {
+        match self {
+            OversamplingRatio::Osr256 => command::CONVERT_D2_OSR_256,
+            OversamplingRatio::Osr512 => command::CONVERT_D2_OSR_512,
+            OversamplingRatio::Osr1024 => command::CONVERT_D2_OSR_1024,
+            OversamplingRatio::Osr2048 => command::CONVERT_D2_OSR_2048,
+            OversamplingRatio::Osr4096 => command::CONVERT_D2_OSR_4096,
+        }
+    }
+
+    /// Get the maximum conversion time in microseconds (based on datasheet max values)
+    fn conversion_time_us(self) -> u32 {
+        match self {
+            OversamplingRatio::Osr256 => 600,
+            OversamplingRatio::Osr512 => 1_170,
+            OversamplingRatio::Osr1024 => 2_280,
+            OversamplingRatio::Osr2048 => 4_540,
+            OversamplingRatio::Osr4096 => 9_040,
+        }
+    }
+}
+
+/// Calibration Coefficients read from PROM
+#[derive(Debug, Clone, Copy)]
+struct CalibrationCoefficients {
+    /// C1: Pressure sensitivity (SENST1)
+    c1_sens_t1: u16,
+    /// C2: Pressure offset (OFFT1)
+    c2_off_t1: u16,
+    /// C3: Temperature coefficient of pressure sensitivity (TCS)
+    c3_tcs: u16,
+    /// C4: Temperature coefficient of pressure offset (TCO)
+    c4_tco: u16,
+    /// C5: Reference temperature (TREF)
+    c5_t_ref: u16,
+    /// C6: Temperature coefficient of the temperature (TEMPSENS)
+    c6_temp_sens: u16,
+    // C7 (Serial/CRC) is read but maybe only used for CRC check, not stored here yet
+}
+
+/// MS5611 Driver Error
+#[derive(Debug)]
+pub enum Error<SPIE, CSE> {
+    /// SPI communication error
+    Spi(SPIE),
+    /// Chip Select pin error
+    Cs(CSE),
+    /// CRC check failed on PROM data (Not yet implemented)
+    CrcError,
+    /// Calculation resulted in an invalid value (e.g. NaN or Infinity)
+    /// This might indicate issues with raw data or coefficients.
+    CalculationFault,
+}
+
+/// MS5611 Driver
+pub struct Ms5611<SPI, CS, DELAY> {
+    spi: SPI,
+    cs: CS,
+    delay: DELAY,
+    coefficients: CalibrationCoefficients,
+}
+
+// Helper macro for handling CS pin toggling
+macro_rules! with_cs {
+    ($self:expr, $block:expr) => {{
+        // Set CS low to start transaction
+        $self.cs.set_low().map_err(Error::Cs)?;
+        // Small delay might be needed depending on SPI speed and device, though often not.
+        // $self.delay.delay_us(1);
+        let result = $block;
+        // Set CS high to end transaction
+        $self.cs.set_high().map_err(Error::Cs)?;
+        result
+    }};
+}
+
+impl<SPI, CS, DELAY, SPIE, CSE> Ms5611<SPI, CS, DELAY>
+where
+    SPI: Transfer<u8, Error = SPIE> + Write<u8, Error = SPIE>,
+    CS: OutputPin<Error = CSE>,
+    DELAY: DelayUs<u32>,
+{
+    /// Creates a new MS5611 driver instance.
+    /// Performs a reset, waits, and reads calibration coefficients from the PROM.
+    pub fn new(spi: SPI, mut cs: CS, mut delay: DELAY) -> Result<Self, Error<SPIE, CSE>> {
+        // Ensure CS is high initially
+        cs.set_high().map_err(Error::Cs)?;
+        delay.delay_us(100); // Small delay after power-up before reset
+
+        let mut sensor = Self {
+            spi,
+            cs,
+            delay,
+            // Placeholder coefficients, will be overwritten
+            coefficients: CalibrationCoefficients {
+                c1_sens_t1: 0,
+                c2_off_t1: 0,
+                c3_tcs: 0,
+                c4_tco: 0,
+                c5_t_ref: 0,
+                c6_temp_sens: 0,
+            },
+        };
+
+        sensor.reset()?;
+        // Datasheet: Wait 2.8 ms (max) after reset
+        sensor.delay.delay_us(3000);
+
+        sensor.coefficients = sensor.read_coefficients()?;
+
+        // Optional: Implement CRC check here using PROM word 7 (0xAE)
+
+        Ok(sensor)
+    }
+
+    /// Sends the Reset command to the sensor.
+    fn reset(&mut self) -> Result<(), Error<SPIE, CSE>> {
+        with_cs!(self, {
+            self.spi.write(&[command::RESET]).map_err(Error::Spi)
+        })
+    }
+
+    /// Reads a 16-bit word from the specified PROM address.
+    fn read_prom_word(&mut self, address_command: u8) -> Result<u16, Error<SPIE, CSE>> {
+        with_cs!(self, {
+            // 1. Send PROM read command for the specific address
+            //    We only write the command, ignore anything read back during this byte.
+            self.spi.write(&[address_command]).map_err(Error::Spi)?;
+
+            // 2. Immediately transfer two dummy bytes (e.g., 0x00) to clock out
+            //    the 16-bit result from the sensor.
+            let mut buffer = [0u8; 2]; // Buffer to receive the 2 bytes
+            self.spi.transfer(&mut buffer).map_err(Error::Spi)?;
+
+            // 3. Construct the u16 result from the received bytes.
+            Ok(u16::from_be_bytes([buffer[0], buffer[1]]))
+        })
+    }
+
+    /// Reads all calibration coefficients (C1-C6) from the PROM.
+    fn read_coefficients(&mut self) -> Result<CalibrationCoefficients, Error<SPIE, CSE>> {
+        // Note: PROM address 0 (0xA0) is reserved, address 7 (0xAE) is CRC/Serial
+        Ok(CalibrationCoefficients {
+            c1_sens_t1: self.read_prom_word(command::PROM_READ_ADDR_1)?,
+            c2_off_t1: self.read_prom_word(command::PROM_READ_ADDR_2)?,
+            c3_tcs: self.read_prom_word(command::PROM_READ_ADDR_3)?,
+            c4_tco: self.read_prom_word(command::PROM_READ_ADDR_4)?,
+            c5_t_ref: self.read_prom_word(command::PROM_READ_ADDR_5)?,
+            c6_temp_sens: self.read_prom_word(command::PROM_READ_ADDR_6)?,
+        })
+    }
+
+    /// Sends a conversion command (Pressure or Temperature).
+    fn start_conversion(&mut self, command: u8) -> Result<(), Error<SPIE, CSE>> {
+        with_cs!(self, { self.spi.write(&[command]).map_err(Error::Spi) })
+    }
+
+    /// Reads the 24-bit raw ADC result from the sensor.
+    fn read_adc_raw(&mut self) -> Result<u32, Error<SPIE, CSE>> {
+        with_cs!(self, {
+            // Send ADC Read command (0x00) to clock out the data
+            let mut buffer = [command::ADC_READ, 0x00, 0x00, 0x00]; // Send read cmd, receive 3 bytes
+            self.spi.transfer(&mut buffer).map_err(Error::Spi)?;
+            Ok(u32::from_be_bytes([0, buffer[1], buffer[2], buffer[3]])) // Pad to 4 bytes for u32
+        })
+    }
+
+    /// Reads the raw temperature value (D2).
+    /// Starts conversion, waits, and reads the ADC.
+    pub fn read_raw_temperature(
+        &mut self,
+        osr: OversamplingRatio,
+    ) -> Result<u32, Error<SPIE, CSE>> {
+        self.start_conversion(osr.temperature_command())?;
+        self.delay.delay_us(osr.conversion_time_us());
+        self.read_adc_raw()
+    }
+
+    /// Reads the raw pressure value (D1).
+    /// Starts conversion, waits, and reads the ADC.
+    pub fn read_raw_pressure(&mut self, osr: OversamplingRatio) -> Result<u32, Error<SPIE, CSE>> {
+        self.start_conversion(osr.pressure_command())?;
+        self.delay.delay_us(osr.conversion_time_us());
+        self.read_adc_raw()
+    }
+
+    /// Performs a full temperature and pressure reading cycle and returns compensated values.
+    /// Reads temperature (D2), then pressure (D1), then performs calculations.
+    ///
+    /// Returns `(temperature_celsius, pressure_mbar)`
+    pub fn read_pressure_temperature(
+        &mut self,
+        osr: OversamplingRatio,
+    ) -> Result<(f32, f32), Error<SPIE, CSE>> {
+        let d2_raw = self.read_raw_temperature(osr)?;
+        let d1_raw = self.read_raw_pressure(osr)?;
+
+        self.calculate_compensated_values(d1_raw, d2_raw)
+    }
+
+    /// Calculates compensated temperature and pressure using raw ADC values and PROM coefficients.
+    /// Implements the 1st and 2nd order compensation formulas from the datasheet.
+    ///
+    /// Returns `(temperature_celsius, pressure_mbar)`
+    fn calculate_compensated_values(
+        &self,
+        d1_raw: u32, // Raw Pressure
+        d2_raw: u32, // Raw Temperature
+    ) -> Result<(f32, f32), Error<SPIE, CSE>> {
+        let c = &self.coefficients;
+
+        // Cast coefficients to i64 for intermediate calculations to prevent overflow
+        let c1 = c.c1_sens_t1 as i64;
+        let c2 = c.c2_off_t1 as i64;
+        let c3 = c.c3_tcs as i64;
+        let c4 = c.c4_tco as i64;
+        let c5 = c.c5_t_ref as i64;
+        let c6 = c.c6_temp_sens as i64;
+        let d1 = d1_raw as i64;
+        let d2 = d2_raw as i64;
+
+        // --- First Order Calculation ---
+        // dT = D2 - C5 * 2^8
+        let dt = d2 - (c5 << 8);
+
+        // TEMP = 2000 + dT * C6 / 2^23  (Result in 0.01 degC)
+        let temp_i32 = (2000 + ((dt * c6) >> 23)) as i32; // Cast to i32 for checks
+
+        // OFF = C2 * 2^16 + (C4 * dT) / 2^7
+        let off = (c2 << 16) + ((c4 * dt) >> 7);
+
+        // SENS = C1 * 2^15 + (C3 * dT) / 2^8
+        let sens = (c1 << 15) + ((c3 * dt) >> 8);
+
+        // --- Second Order Temperature Compensation ---
+        let mut temp = temp_i32 as i64; // Use i64 for further calculations
+        let mut off2 = 0i64;
+        let mut sens2 = 0i64;
+        let mut t2 = 0i64;
+
+        if temp < 2000 {
+            // T2 = dT^2 / 2^31
+            t2 = (dt * dt) >> 31;
+
+            // OFF2 = 5 * (TEMP - 2000)^2 / 2
+            let temp_diff_sq = (temp - 2000) * (temp - 2000);
+            off2 = 5 * temp_diff_sq >> 1; // Divide by 2
+
+            // SENS2 = 5 * (TEMP - 2000)^2 / 4
+            sens2 = 5 * temp_diff_sq >> 2; // Divide by 4
+
+            if temp < -1500 {
+                // OFF2 = OFF2 + 7 * (TEMP + 1500)^2
+                let temp_low_diff_sq = (temp + 1500) * (temp + 1500);
+                off2 += 7 * temp_low_diff_sq;
+                // SENS2 = SENS2 + 11 * (TEMP + 1500)^2 / 2
+                sens2 += 11 * temp_low_diff_sq >> 1; // Divide by 2
+            }
+        }
+
+        // Apply second order corrections
+        temp -= t2;
+        let off_compensated = off - off2;
+        let sens_compensated = sens - sens2;
+
+        // --- Final Pressure Calculation ---
+        // P = (D1 * SENS / 2^21 - OFF) / 2^15 (Result in 0.01 mbar)
+        let p_i32 = (((d1 * sens_compensated) >> 21) - off_compensated) >> 15; // Cast to i32
+
+        // Convert to final units (float)
+        // Handle potential division by zero or NaN/Infinity results from float conversion
+        let temp_celsius = temp as f32 / 100.0;
+        let pressure_mbar = p_i32 as f32 / 100.0;
+
+        // Check for NaN or Infinity which might occur if intermediate calculations were extreme
+        if temp_celsius.is_finite() && pressure_mbar.is_finite() {
+            Ok((temp_celsius, pressure_mbar))
+        } else {
+            Err(Error::CalculationFault)
+        }
+    }
+}

--- a/crates/common-arm/src/drivers/ms5611.rs
+++ b/crates/common-arm/src/drivers/ms5611.rs
@@ -221,7 +221,7 @@ where
     }
 
     /// Reads the 24-bit raw ADC result from the sensor.
-    fn read_adc_raw(&mut self) -> Result<u32, Error<SPIE, CSE>> {
+    pub fn read_adc_raw(&mut self) -> Result<u32, Error<SPIE, CSE>> {
         with_cs!(self, {
             // Send ADC Read command (0x00) to clock out the data
             let mut buffer = [command::ADC_READ, 0x00, 0x00, 0x00]; // Send read cmd, receive 3 bytes

--- a/crates/common-arm/src/drivers/ms5611.rs
+++ b/crates/common-arm/src/drivers/ms5611.rs
@@ -6,7 +6,6 @@ use embedded_hal::{
     },
     digital::v2::OutputPin,
 };
-use defmt::info; // Add this line for logging
 
 // According to datasheet section 4.1
 mod command {
@@ -173,12 +172,6 @@ where
         sensor.delay.delay_us(3000);
 
         sensor.coefficients = sensor.read_coefficients()?;
-        info!("MS5611 PROM C1 (SENS_T1): {}", sensor.coefficients.c1_sens_t1);
-        info!("MS5611 PROM C2 (OFF_T1): {}", sensor.coefficients.c2_off_t1);
-        info!("MS5611 PROM C3 (TCS): {}", sensor.coefficients.c3_tcs);
-        info!("MS5611 PROM C4 (TCO): {}", sensor.coefficients.c4_tco);
-        info!("MS5611 PROM C5 (T_REF): {}", sensor.coefficients.c5_t_ref);
-        info!("MS5611 PROM C6 (TEMP_SENS): {}", sensor.coefficients.c6_temp_sens);
 
         // Optional: Implement CRC check here using PROM word 7 (0xAE)
 
@@ -265,9 +258,7 @@ where
         osr: OversamplingRatio,
     ) -> Result<(f32, f32), Error<SPIE, CSE>> {
         let d2_raw = self.read_raw_temperature(osr)?;
-        info!("MS5611 Raw D2 (temperature): {}", d2_raw);
         let d1_raw = self.read_raw_pressure(osr)?;
-        info!("MS5611 Raw D1 (pressure): {}", d1_raw);
 
         self.calculate_compensated_values(d1_raw, d2_raw)
     }
@@ -282,8 +273,6 @@ where
         d2_raw: u32, // Raw Temperature
     ) -> Result<(f32, f32), Error<SPIE, CSE>> {
         let c = &self.coefficients;
-        info!("MS5611 Calc: Using C1={}, C2={}, C3={}, C4={}, C5={}, C6={}", c.c1_sens_t1, c.c2_off_t1, c.c3_tcs, c.c4_tco, c.c5_t_ref, c.c6_temp_sens);
-        info!("MS5611 Calc: Using D1_raw={}, D2_raw={}", d1_raw, d2_raw);
 
         // Cast coefficients to i64 for intermediate calculations to prevent overflow
         let c1 = c.c1_sens_t1 as i64;
@@ -298,19 +287,15 @@ where
         // --- First Order Calculation ---
         // dT = D2 - C5 * 2^8
         let dt = d2 - (c5 << 8);
-        info!("MS5611 Calc: dt = {}", dt);
 
         // TEMP = 2000 + dT * C6 / 2^23  (Result in 0.01 degC)
         let temp_i32 = (2000 + ((dt * c6) >> 23)) as i32; // Cast to i32 for checks
-        info!("MS5611 Calc: temp_i32 (1st order temp * 100) = {}", temp_i32);
 
         // OFF = C2 * 2^16 + (C4 * dT) / 2^7
         let off = (c2 << 16) + ((c4 * dt) >> 7);
-        info!("MS5611 Calc: off (1st order) = {}", off);
 
         // SENS = C1 * 2^15 + (C3 * dT) / 2^8
         let sens = (c1 << 15) + ((c3 * dt) >> 8);
-        info!("MS5611 Calc: sens (1st order) = {}", sens);
 
         // --- Second Order Temperature Compensation ---
         let mut temp = temp_i32 as i64; // Use i64 for further calculations
@@ -319,7 +304,6 @@ where
         let mut t2 = 0i64;
 
         if temp < 2000 {
-            info!("MS5611 Calc: Applying 2nd order comp for temp < 2000");
             // T2 = dT^2 / 2^31
             t2 = (dt * dt) >> 31;
 
@@ -329,16 +313,13 @@ where
 
             // SENS2 = 5 * (TEMP - 2000)^2 / 4
             sens2 = 5 * temp_diff_sq >> 2; // Divide by 4
-            info!("MS5611 Calc: t2 = {}, off2 = {}, sens2 = {}", t2, off2, sens2);
 
             if temp < -1500 {
-                info!("MS5611 Calc: Applying 2nd order comp for temp < -1500");
                 // OFF2 = OFF2 + 7 * (TEMP + 1500)^2
                 let temp_low_diff_sq = (temp + 1500) * (temp + 1500);
                 off2 += 7 * temp_low_diff_sq;
                 // SENS2 = SENS2 + 11 * (TEMP + 1500)^2 / 2
                 sens2 += 11 * temp_low_diff_sq >> 1; // Divide by 2
-                info!("MS5611 Calc: (temp < -1500) adjusted off2 = {}, sens2 = {}", off2, sens2);
             }
         }
 
@@ -346,14 +327,10 @@ where
         temp -= t2;
         let off_compensated = off - off2;
         let sens_compensated = sens - sens2;
-        info!("MS5611 Calc: final compensated temp_int (*100) = {}", temp);
-        info!("MS5611 Calc: final compensated off = {}", off_compensated);
-        info!("MS5611 Calc: final compensated sens = {}", sens_compensated);
 
         // --- Final Pressure Calculation ---
         // P = (D1 * SENS / 2^21 - OFF) / 2^15 (Result in 0.01 mbar)
         let p_i32 = (((d1 * sens_compensated) >> 21) - off_compensated) >> 15; // Cast to i32
-        info!("MS5611 Calc: p_i32 (final pressure * 10000 in Pa, or * 100 in mbar) = {}", p_i32);
 
         // Convert to final units (float)
         // Handle potential division by zero or NaN/Infinity results from float conversion

--- a/crates/common-arm/src/error/hydra_error.rs
+++ b/crates/common-arm/src/error/hydra_error.rs
@@ -5,6 +5,8 @@ use derive_more::From;
 use embedded_sdmmc as sd;
 use messages::ErrorContext;
 use nb::Error as NbError;
+
+use crate::drivers::ms5611;
 /// Open up atsamd hal errors without including the whole crate.
 
 /// Contains all the various error types that can be encountered in the Hydra codebase. Extra errors
@@ -19,6 +21,8 @@ pub enum HydraErrorType {
     SpawnError(&'static str),
     /// Error from the SD card library.
     SdCardError(sd::Error<sd::SdMmcError>),
+    /// Error from the Baro driver.
+    BaroError(ms5611::Error<stm32h7xx_hal::spi::Error, core::convert::Infallible>),
     /// Error from the Mavlink library.
     MavlinkError(messages::mavlink::error::MessageWriteError),
     MavlinkReadError(messages::mavlink::error::MessageReadError),
@@ -48,6 +52,9 @@ impl defmt::Format for HydraErrorType {
             }
             HydraErrorType::NbError(_) => {
                 write!(f, "Nb error!");
+            }
+            HydraErrorType::BaroError(_) => {
+                write!(f, "Baro error!");
             }
         }
     }

--- a/crates/common-arm/src/lib.rs
+++ b/crates/common-arm/src/lib.rs
@@ -6,6 +6,7 @@
 //! here.
 //!
 
+pub mod drivers;
 mod error;
 mod logging;
 mod sd_manager;

--- a/phoenix/src/data_manager.rs
+++ b/phoenix/src/data_manager.rs
@@ -24,6 +24,9 @@ pub struct DataManager {
     pub logging_rate: Option<RadioRate>,
     pub recovery_sensing: Option<Message>,
     pub nav_pos_l1h: Option<Message>,
+    // Barometer
+    pub baro_temperature: Option<f32>,
+    pub baro_pressure: Option<f32>,
 }
 
 impl DataManager {
@@ -48,6 +51,8 @@ impl DataManager {
             logging_rate: Some(RadioRate::Slow), // start slow.
             recovery_sensing: None,
             nav_pos_l1h: None,
+            baro_temperature: None,
+            baro_pressure: None,
         }
     }
 

--- a/phoenix/src/main.rs
+++ b/phoenix/src/main.rs
@@ -375,20 +375,20 @@ mod app {
             info!("Starting barometer reading cycle");
             cx.shared.em.run(|| {
                 // Choose the desired Oversampling Ratio for this reading
-                let osr = OversamplingRatio::Osr4096; // Example: Highest precision
-                info!("Reading with OSR: {}", osr as u8);
+                let osr = OversamplingRatio::Osr512; // Example: Highest precision
+                info!("Baro: Using OSR: {}", osr as u8);
 
                 match baro.read_pressure_temperature(osr) {
-                    Ok((temp_c, press_mbar)) => {
-                        info!("Barometer reading successful - Temp: {}, Pressure: {}", temp_c, press_mbar);
+                    Ok((temp_c, press_kpa)) => {
+                        info!("Baro: Driver output - Temp: {} C, Pressure: {} kPa", temp_c, press_kpa);
                         cx.shared.data_manager.lock(|dm| {
                             dm.baro_temperature = Some(temp_c);
-                            dm.baro_pressure = Some(press_mbar);
+                            dm.baro_pressure = Some(press_kpa);
                         });
                         Ok(())
                     }
                     Err(e) => {
-                        info!("Barometer reading failed");
+                        info!("Baro: Driver reading failed!");
                         cx.shared.data_manager.lock(|dm| {
                             dm.baro_temperature = None;
                             dm.baro_pressure = None;
@@ -397,7 +397,7 @@ mod app {
                     }
                 }
             });
-            Mono::delay(3.millis()).await;
+            Mono::delay(1000.millis()).await;
         }
     }
 

--- a/phoenix/src/main.rs
+++ b/phoenix/src/main.rs
@@ -372,15 +372,12 @@ mod app {
     async fn baro_read(mut cx: baro_read::Context) {
         let baro = cx.local.baro; // Get mutable access to the driver
         loop {
-            info!("Starting barometer reading cycle");
             cx.shared.em.run(|| {
                 // Choose the desired Oversampling Ratio for this reading
                 let osr = OversamplingRatio::Osr512; // Example: Highest precision
-                info!("Baro: Using OSR: {}", osr as u8);
 
                 match baro.read_pressure_temperature(osr) {
                     Ok((temp_c, press_kpa)) => {
-                        info!("Baro: Driver output - Temp: {} C, Pressure: {} kPa", temp_c, press_kpa);
                         cx.shared.data_manager.lock(|dm| {
                             dm.baro_temperature = Some(temp_c);
                             dm.baro_pressure = Some(press_kpa);

--- a/phoenix/src/main.rs
+++ b/phoenix/src/main.rs
@@ -46,7 +46,7 @@ fn panic() -> ! {
 mod app {
 
     use messages::Message;
-    use stm32h7xx_hal::gpio::{Alternate, Pin};
+    use stm32h7xx_hal::{delay::Delay, gpio::{Alternate, Pin}};
 
     use super::*;
 
@@ -73,6 +73,11 @@ mod app {
             stm32h7xx_hal::pac::TIM12,
             0,
             stm32h7xx_hal::pwm::ComplementaryImpossible,
+        >,
+        baro: common_arm::drivers::ms5611::Ms5611<
+            stm32h7xx_hal::pac::SPIx,
+            
+            
         >,
     }
 
@@ -325,6 +330,20 @@ mod app {
                 buzzer: c0,
             },
         )
+    }
+
+    // it would be nice to have RTIC be able to return objects, but the current procedural macro
+    // does not allow for this.
+    #[task(priority = 2, local = [baro], shared = [&em, data_manager])]
+    async fn baro_read(mut cx: baro_read::Context) {
+        loop {
+            cx.shared.em.run(|| {
+                
+
+                Ok(())
+            })
+            Mono::delay(3.millis()).await;
+        }
     }
 
     #[task(priority = 3, shared = [&em, rtc])]

--- a/probe-rs.yaml
+++ b/probe-rs.yaml
@@ -1,0 +1,9 @@
+probe:
+  # Increase SWD clock frequency to 4MHz (default is usually 1MHz)
+  speed: 4000
+  # Use SWD protocol
+  protocol: swd
+  # Enable faster flash operations
+  flash_algorithm:
+    enable_fast_program: true
+    enable_verify: false  # Skip verification for faster flashing 


### PR DESCRIPTION
Adds a blocking driver for the MS5611 barometric sensor inside common-arm.

Before adding the non-blocking part with RTIC I believe its better to first double check if it initially works on hardware.